### PR TITLE
Reimplement fullHash feature based on custom layer-name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 leaflet-fullHash
 ================
 
-Add dynamic URL hash for Leaflet map (map view and active layers). For those who also lack layers state in [leaflet-hash plugin](https://github.com/mlevans/leaflet-hash). Now you can easily link user to specific map view with certain active layers. 
+Add dynamic URL hash for Leaflet map (map view and active layers). For those who also lack layers state in [leaflet-hash plugin](https://github.com/mlevans/leaflet-hash). Now you can easily link user to specific map view with certain active layers.
 
 ### Demo
 You can view a demo of leaflet-fullHash here: [kogor.github.io/leaflet-fullHash](http://kogor.github.io/leaflet-fullHash/index.html).
@@ -12,13 +12,18 @@ You can view a demo of leaflet-fullHash here: [kogor.github.io/leaflet-fullHash]
 2. Once you have initialized the map (an instance of [L.Map](http://leafletjs.com/reference.html#map-class)), add the following code:
 
 	```javascript
+        var osm = L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+            name: 'osm', // this name will be used for the hash-URL
+            maxZoom: 19,
+            attribution: '© <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+        });
+        // …
         // Assuming your map instance is in a variable called map
-        var allMapLayers = {'base_layer_name': leaflet_layer_object,
-                            'overlay_name': leaflet_layer_object,
-                            'another_overlay_name': leaflet_layer_object};
+        var allMapLayers = {'Public Name 1': osm,
+                            'Public Name 2': leaflet_layer_object2,
+                            'Public Name 3': leaflet_layer_object3};
         var hash = new L.Hash(map, allMapLayers);
     ```
-Here `leaflet_layer_object` should be instance of any Leaflet layer (based on [ILayer](http://leafletjs.com/reference.html#ilayer)).
 
 ### License
 

--- a/leaflet-fullHash.js
+++ b/leaflet-fullHash.js
@@ -1,35 +1,35 @@
-(function(window) {
-	var HAS_HASHCHANGE = (function() {
+(function (window) {
+	var HAS_HASHCHANGE = (function () {
 		var doc_mode = window.documentMode;
 		return ('onhashchange' in window) &&
 			(doc_mode === undefined || doc_mode > 7);
 	})();
 
-	L.Hash = function(map, options) {
+	L.Hash = function (map, layers) {
 		this.onHashChange = L.Util.bind(this.onHashChange, this);
 
-		if (map) {
-			this.init(map, options);
+		if (map && layers) {
+			this.init(map, layers);
 		}
 	};
 
-	L.Hash.parseHash = function(hash) {
-		if(hash.indexOf('#') === 0) {
+	L.Hash.parseHash = function (hash) {
+		if (hash.indexOf('#') === 0) {
 			hash = hash.substr(1);
 		}
 		var args = hash.split("/");
 		if (args.length == 4) {
 			var zoom = parseInt(args[0], 10),
-			lat = parseFloat(args[1]),
-			lon = parseFloat(args[2]),
-			layers = (args[3]).split("-");
+				lat = parseFloat(args[1]),
+				lon = parseFloat(args[2]),
+				layer = args[3];
 			if (isNaN(zoom) || isNaN(lat) || isNaN(lon)) {
 				return false;
 			} else {
 				return {
 					center: new L.LatLng(lat, lon),
 					zoom: zoom,
-					layers: layers
+					layer: layer
 				};
 			}
 		} else {
@@ -37,40 +37,21 @@
 		}
 	};
 
-	L.Hash.formatHash = function(map) {
-		var center = map.getCenter(),
-		    zoom = map.getZoom(),
-		    precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2)),
-		    layers = [];
-
-		//console.log(this.options);
-		var options = this.options;
-		//Check active layers
-		for(var key in options) {
-			if (options.hasOwnProperty(key)) {
-				if (map.hasLayer(options[key])) {
-					layers.push(key);
-				};
-			};
-		};
-
-		return "#" + [zoom,
-			center.lat.toFixed(precision),
-			center.lng.toFixed(precision),
-			layers.join("-")
-		].join("/");
+	L.Hash.formatHash = function (zoom, lat, lng, layer_name) {
+		return "#" + [zoom, lat, lng, layer_name].join("/");
 	},
 
 	L.Hash.prototype = {
 		map: null,
+		layers: null,
 		lastHash: null,
 
 		parseHash: L.Hash.parseHash,
 		formatHash: L.Hash.formatHash,
 
-		init: function(map, options) {
+		init: function (map, layers) {
 			this.map = map;
-			L.Util.setOptions(this, options);
+			this.layers = layers;
 
 			// reset the hash
 			this.lastHash = null;
@@ -81,7 +62,7 @@
 			}
 		},
 
-		removeFrom: function(map) {
+		removeFrom: function (map) {
 			if (this.changeTimeout) {
 				clearTimeout(this.changeTimeout);
 			}
@@ -93,15 +74,33 @@
 			this.map = null;
 		},
 
-		onMapMove: function() {
+		onMapMoveOrLayerChange: function (event) {
 			// bail if we're moving the map (updating from a hash),
 			// or if the map is not yet loaded
 
-			if (this.movingMap || !this.map._loaded) {
+			if (this.movingMap || !this.map._loaded || event === undefined) {
 				return false;
 			}
 
-			var hash = this.formatHash(this.map);
+			var center = map.getCenter(),
+				zoom = map.getZoom(),
+				precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2)),
+				lat = center.lat.toFixed(precision),
+				lng = center.lng.toFixed(precision),
+				layer_name = '';
+
+			if (event.type === "baselayerchange") {
+				layer_name = event.layer.options.name
+			} else {
+				// event.type==moveend: when just moving, take the currently active layer
+				// todo: in my case map._layers has only one entry. But this is probably false
+				//   in cases that use overlays. So this will likele need another check to select the baselayer
+				// TODO: this would be more elegant if we checked with map.hasLayer if a given layer from this.layers
+				//   exists; but we first need to find a way to select this layer by the name in the hash.
+				this.map.eachLayer(function (layer) { layer_name = layer.options.name })
+			}
+
+			var hash = this.formatHash(zoom, lat, lng, layer_name);
 			if (this.lastHash != hash) {
 				location.replace(hash);
 				this.lastHash = hash;
@@ -109,7 +108,7 @@
 		},
 
 		movingMap: false,
-		update: function() {
+		update: function () {
 			var hash = location.hash;
 			if (hash === this.lastHash) {
 				return;
@@ -119,34 +118,29 @@
 				this.movingMap = true;
 
 				this.map.setView(parsed.center, parsed.zoom);
-				var layers = parsed.layers,
-					options = this.options,
-					that = this;
-				//Add/remove layers
-				this.map.eachLayer(function(layer) {
-					that.map.removeLayer(layer);
-				});
 
-				layers.forEach(function(element, index, array) {
-					//console.log(options[element]);
-					that.map.addLayer(options[element]);
-				});			
+				Object.keys(this.layers).map(layer_key => {
+					var layer = this.layers[layer_key]
+					if (layer.options.name === parsed.layer) {
+						this.map.addLayer(layer)
+					}
+				})
 
 				this.movingMap = false;
 			} else {
-				this.onMapMove(this.map);
+				this.onMapMoveOrLayerChange();
 			}
 		},
 
 		// defer hash change updates every 100ms
 		changeDefer: 100,
 		changeTimeout: null,
-		onHashChange: function() {
+		onHashChange: function () {
 			// throttle calls to update() so that they only happen every
 			// `changeDefer` ms
 			if (!this.changeTimeout) {
 				var that = this;
-				this.changeTimeout = setTimeout(function() {
+				this.changeTimeout = setTimeout(function () {
 					that.update();
 					that.changeTimeout = null;
 				}, this.changeDefer);
@@ -155,8 +149,8 @@
 
 		isListening: false,
 		hashChangeInterval: null,
-		startListening: function() {
-			this.map.on("moveend layeradd layerremove", this.onMapMove, this);
+		startListening: function () {
+			this.map.on("moveend baselayerchange", this.onMapMoveOrLayerChange, this);
 
 			if (HAS_HASHCHANGE) {
 				L.DomEvent.addListener(window, "hashchange", this.onHashChange);
@@ -167,8 +161,8 @@
 			this.isListening = true;
 		},
 
-		stopListening: function() {
-			this.map.off("moveend layeradd layerremove", this.onMapMove, this);
+		stopListening: function () {
+			this.map.off("moveend baselayerchange", this.onMapMoveOrLayerChange, this);
 
 			if (HAS_HASHCHANGE) {
 				L.DomEvent.removeListener(window, "hashchange", this.onHashChange);
@@ -176,25 +170,15 @@
 				clearInterval(this.hashChangeInterval);
 			}
 			this.isListening = false;
-		},
-
-		_keyByValue: function(obj, value) {
-			for(var key in obj) {
-				if (obj.hasOwnProperty(key)) {
-					if (obj[key] === value) {
-						return key;
-					} else { return null; };
-				};
-			};
 		}
 	};
-	L.hash = function(map, options) {
-		return new L.Hash(map, options);
+	L.hash = function (map) {
+		return new L.Hash(map);
 	};
-	L.Map.prototype.addHash = function() {
-		this._hash = L.hash(this, this.options);
+	L.Map.prototype.addHash = function () {
+		this._hash = L.hash(this);
 	};
-	L.Map.prototype.removeHash = function() {
+	L.Map.prototype.removeHash = function () {
 		this._hash.removeFrom();
 	};
 })(window);


### PR DESCRIPTION
Now, that I got this far, I realise that my version is not far of yours.
I will show it to you anyways in case someone can take something away from this.

- the layer name in the URL is based on a custom name that is part of the tileLayer object
- the hash-url only has this custom name
- we listen on `baselayerchange`, not `layeradd layerremove`

This version is base on https://github.com/mlevans/leaflet-hash from Oct 2013.

This version is online at https://supaplexosm.github.io/parkraumkarte-neukoelln/#18/52.48150/13.43571/parkingmap
Repo at https://github.com/SupaplexOSM/parkraumkarte-neukoelln

Still todo IMO is
- [ ] Check if overlays break this logic, see code comment in line 96.